### PR TITLE
DCMAW-13074: Added 200 response and unit tests

### DIFF
--- a/backend/src/common/logging/LogMessages.ts
+++ b/backend/src/common/logging/LogMessages.ts
@@ -25,6 +25,12 @@ export class LogMessage implements LogAttributes {
     "N/A",
   );
 
+  static readonly REVOKE_HANDLER_CALLED = new LogMessage(
+    "REVOKE_HANDLER_CALLED",
+    "Revoke handler has been called.",
+    "N/A",
+  );
+  
   private constructor(
     public readonly messageCode: string,
     public readonly message: string,

--- a/backend/src/common/logging/LogMessages.ts
+++ b/backend/src/common/logging/LogMessages.ts
@@ -25,8 +25,8 @@ export class LogMessage implements LogAttributes {
     "N/A",
   );
 
-  static readonly REVOKE_HANDLER_CALLED = new LogMessage(
-    "REVOKE_HANDLER_CALLED",
+  static readonly REVOKE_LAMBDA_CALLED = new LogMessage(
+    "REVOKE_LAMBDA_CALLED",
     "Revoke handler has been called.",
     "N/A",
   );

--- a/backend/src/common/logging/LogMessages.ts
+++ b/backend/src/common/logging/LogMessages.ts
@@ -30,7 +30,7 @@ export class LogMessage implements LogAttributes {
     "Revoke handler has been called.",
     "N/A",
   );
-  
+
   private constructor(
     public readonly messageCode: string,
     public readonly message: string,

--- a/backend/src/functions/revokeHandler.ts
+++ b/backend/src/functions/revokeHandler.ts
@@ -17,7 +17,7 @@ export function handler(
   context: Context,
 ): Promise<APIGatewayProxyResult> {
   setupLogger(context);
-  logger.info(LogMessage.REVOKE_HANDLER_CALLED);
+  logger.info(LogMessage.REVOKE_LAMBDA_CALLED);
 
   return Promise.resolve({
     statusCode: 202,

--- a/backend/src/functions/revokeHandler.ts
+++ b/backend/src/functions/revokeHandler.ts
@@ -1,6 +1,31 @@
-export function handler(): Response {
-  return new Response(null, {
-    status: 501,
-    statusText: "Not Implemented",
+import { logger } from "../common/logging/logger";
+import { LogMessage } from "../common/logging/LogMessages";
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Context,
+} from "aws-lambda";
+
+function setupLogger(context: Context) {
+  logger.resetKeys();
+  logger.addContext(context);
+  logger.appendKeys({ functionVersion: context.functionVersion });
+}
+
+export function handler(
+  event: APIGatewayProxyEvent,
+  context: Context,
+): Promise<APIGatewayProxyResult> {
+  setupLogger(context);
+  logger.info(LogMessage.REVOKE_HANDLER_CALLED);
+
+  return Promise.resolve({
+    statusCode: 202,
+    body: JSON.stringify({
+      message: "Request accepted for revocation",
+    }),
+    headers: {
+      "Content-Type": "application/json",
+    },
   });
 }

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -452,8 +452,9 @@ Resources:
   # Revoke Lambda
   RevokeFunction:
     Type: AWS::Serverless::Function
-    DependsOn:
-      - RevokeLogGroup
+
+    # DependsOn:
+    #   - RevokeLogGroup
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -478,6 +479,9 @@ Resources:
             Fn::Sub: ${VpcStackName}-ProtectedSubnetIdB
           - !ImportValue
             Fn::Sub: ${VpcStackName}-ProtectedSubnetIdC
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: Revoke
 
   RevokeFunctionLambdaRole:
     Type: AWS::IAM::Role
@@ -521,14 +525,21 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
-  RevokeLogGroup:
-    Type: AWS::Logs::LogGroup
+  RevokeVersionMetricFilter:
+    Type: AWS::Logs::MetricFilter
     Properties:
-      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-revoke-logs
-      RetentionInDays: !FindInMap
-        - LogRetention
-        - !Ref Environment
-        - RetentionPeriod
+      FilterPattern: '{ ($.messageCode = *) && ($.functionVersion = *) }'
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-revoke
+      MetricTransformations:
+        - Dimensions:
+            - Key: MessageCode
+              Value: $.messageCode
+            - Key: Version
+              Value: $.functionVersion
+          MetricName: RevokeMessageCode
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          MetricValue: "1"
+    Condition: DeployMetricFilters
 
   CSLSRevokeFunctionSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -538,7 +549,7 @@ Resources:
         - !Ref Environment
         - CSLSEGRESS
       FilterPattern: ""
-      LogGroupName: !Ref RevokeLogGroup
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-revoke
     Condition: IsProdLikeEnvironment
 
   RevokeAccessLogs:

--- a/backend/test/unit/revoke/revoke.test.ts
+++ b/backend/test/unit/revoke/revoke.test.ts
@@ -18,10 +18,7 @@ jest.mock("../../../src/common/logging/logger", () => ({
 
 describe("revoke handler", () => {
   const mockEvent = {} as APIGatewayProxyEvent;
-  const mockContext = {
-    functionVersion: "v1.0",
-    awsRequestId: "test-request-id",
-  } as Context;
+  const mockContext = { functionVersion: "1" } as Context;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -59,6 +56,6 @@ describe("revoke handler", () => {
   it("should log the handler being called", async () => {
     await handler(mockEvent, mockContext);
 
-    expect(logger.info).toHaveBeenCalledWith(LogMessage.REVOKE_HANDLER_CALLED);
+    expect(logger.info).toHaveBeenCalledWith(LogMessage.REVOKE_LAMBDA_CALLED);
   });
 });

--- a/backend/test/unit/revoke/revoke.test.ts
+++ b/backend/test/unit/revoke/revoke.test.ts
@@ -1,10 +1,64 @@
 import { handler } from "../../../src/functions/revokeHandler";
-import { describe, test, expect } from "@jest/globals";
+import { logger } from "../../../src/common/logging/logger";
+import { LogMessage } from "../../../src/common/logging/LogMessages";
+import { Context, APIGatewayProxyEvent } from "aws-lambda";
 
-describe("testing handler setup correctly", () => {
-  test("handler should return appropriate response", () => {
-    expect(handler()).toBeInstanceOf(Response);
-    expect(handler().status).toBe(501);
-    expect(handler().statusText).toBe("Not Implemented");
+// Mock the logger
+jest.mock("../../../src/common/logging/logger", () => ({
+  logger: {
+    resetKeys: jest.fn(),
+    addContext: jest.fn(),
+    appendKeys: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("revoke handler", () => {
+  const mockEvent = {} as APIGatewayProxyEvent;
+  const mockContext = {
+    functionVersion: "v1.0",
+    awsRequestId: "test-request-id",
+  } as Context;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 202 Accepted status code", async () => {
+    const response = await handler(mockEvent, mockContext);
+
+    expect(response.statusCode).toBe(202);
+  });
+
+  it("should return correct message in response body", async () => {
+    const response = await handler(mockEvent, mockContext);
+    const body = JSON.parse(response.body);
+
+    expect(body).toEqual({ message: "Request accepted for revocation" });
+  });
+
+  it("should return correct Content-Type header", async () => {
+    const response = await handler(mockEvent, mockContext);
+
+    expect(response.headers).toEqual({ "Content-Type": "application/json" });
+  });
+
+  it("should setup logger with context", async () => {
+    await handler(mockEvent, mockContext);
+
+    expect(logger.resetKeys).toHaveBeenCalledTimes(1);
+    expect(logger.addContext).toHaveBeenCalledWith(mockContext);
+    expect(logger.appendKeys).toHaveBeenCalledWith({
+      functionVersion: mockContext.functionVersion,
+    });
+  });
+
+  it("should log the handler being called", async () => {
+    await handler(mockEvent, mockContext);
+
+    expect(logger.info).toHaveBeenCalledWith(LogMessage.REVOKE_HANDLER_CALLED);
   });
 });


### PR DESCRIPTION
## JIRA Ticket

[DCMAW-13074](https://govukverify.atlassian.net/browse/DCMAW-13074)

## Description of Changes

Hardcoded 202 Accepted response ([as per RFC](https://github.com/govuk-one-login/architecture/blob/main/rfc/0100-credential-revocation.md#revoke)) with a dummy body.

Added logging, metric filters and unit tests.

## Evidence

![image](https://github.com/user-attachments/assets/a68548b2-ffa9-4e74-982a-e00d8ef754a3)
Lambda response

![image](https://github.com/user-attachments/assets/d85c2263-839f-40c9-9f57-a042551ff11b)
Lambda logs

## Documentation

N/A

---

<details>
<summary><h2>Guidance for Reviewers</h2></summary>

### Functionality
* Have all of the ticket requirements and acceptance criteria been met?
* Will this code function as expected in different environments?

### Testing

* Is every component covered by high quality unit tests?
* Have API/end-to-end tests been updated to cover key new behaviour?
* Have infra tests been added if needed for changes to our templates?

### Logging

* Are the changes supported by sufficient logging to help support, debug and analyse the behaviour of the service?
* Is anything being logged that shouldn't be? (PII, redundant information)

### Code Quality

* Does the code conform to our [values, principles and practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3910271319/Values+Principles+and+Practices) for high quality code?

### Documentation

* Has any relevant reference documentation been updated?
* Would any further documentation of the changes make the service easier to understand and maintain?

</details>


[DCMAW-13074]: https://govukverify.atlassian.net/browse/DCMAW-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ