### PR TITLE
DCMAW-14551: Lower FAS error alarm threshold

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -744,7 +744,7 @@ Resources:
       AlarmName: !Sub ${AWS::StackName}-find-available-slots-error-rate
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      Threshold: 10
+      Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -736,7 +736,7 @@ Resources:
       OKActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
       AlarmDescription: !Sub
-        - 'The number of Find Available Slots Lambda errors is greater than or equal to 10% for the latest function version. See runbook: ${WarningAlarmsRunbookUrl}'
+        - 'The number of Find Available Slots Lambda errors is greater than or equal to 1% for the latest function version. See runbook: ${WarningAlarmsRunbookUrl}'
         - WarningAlarmsRunbookUrl: !FindInMap
             - StaticVariables
             - urls


### PR DESCRIPTION
## JIRA Ticket

[DCMAW-14551](https://govukverify.atlassian.net/browse/DCMAW-14551)

## Description of Changes

Changed the error rate alarm threshold from 10% down to 1% of all the lambda runs

## Evidence

N/A

## Documentation

N/A

---

<details>
<summary><h2>Guidance for Reviewers</h2></summary>

### Functionality
* Have all of the ticket requirements and acceptance criteria been met?
* Will this code function as expected in different environments?

### Testing

* Is every component covered by high quality unit tests?
* Have API/end-to-end tests been updated to cover key new behaviour?
* Have infra tests been added if needed for changes to our templates?

### Logging

* Are the changes supported by sufficient logging to help support, debug and analyse the behaviour of the service?
* Is anything being logged that shouldn't be? (PII, redundant information)

### Code Quality

* Does the code conform to our [values, principles and practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3910271319/Values+Principles+and+Practices) for high quality code?

### Documentation

* Has any relevant reference documentation been updated?
* Would any further documentation of the changes make the service easier to understand and maintain?

</details>


[DCMAW-14551]: https://govukverify.atlassian.net/browse/DCMAW-14551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ